### PR TITLE
F/2098/generalize

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "6.13.0"
+  hashes = [
+    "h1:+2T5mGN0JeFWxrQx+WVSR+H8+oCY943zmNEVc/Cz1j4=",
+    "h1:K01g96E7e30a7ydomvB2PgH82UtXRCbzRW2qtt0yyb8=",
+    "h1:PpxlbsdUC7HBfbMHGc6A7bWNbCtAl0BnZyplFRNvU8A=",
+    "h1:YiSOZFsdpzXgRN5NB01Fzfs8mvAlTnrM85/QktOhmgw=",
+    "h1:jakE2O6gqqQHIZYnr4K7zCNqlMDO/VMgVbCPbbLT/Oc=",
+    "zh:05067a572a2fcec7ab2e613611db68ff9fdaac18869f76ca53ce308f8f4b904a",
+    "zh:1122fae676ba52d4842267ce8a9e391c262d2468c095b6ad7b0550c1bf292b05",
+    "zh:1cde30b75d4e5ecd8eabcf2f9119302611a2b757f9cd50474c21f30dba77dd60",
+    "zh:444d333a8af09d4f561a09c56eee48cd23e97fca94c427ae5e4a24745418a097",
+    "zh:471303b121adf8b9225de70127f62f3b96033a9ab6e14f9dc7fe19f6d224186d",
+    "zh:4caa73ea78c85dc4abde022d114d4d2ff770636def8f308472e3679ac5195d9a",
+    "zh:6257a064015ed1c277cfb39027b91de2b7bc6f1ce6d42058b9df3d5aa37ecb4f",
+    "zh:8a45fe7f3e4b10ba6e8c5e44fecd0c7389e6f9c8cca11d052a357fbaae615c1a",
+    "zh:8ce6902473efdf92724679c2b63905263d83dcf77bd8d9e9f45701cdc9dcc229",
+    "zh:ce8951ef5ce96d694f7fbcea6d7dd593f6102b3ac1c686e03f08316dd7923d2d",
+    "zh:ef009b465067b8d3646d0c6ca8a6ba860d4591ddc427f005cfa5d4fcac0c4fce",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lock-providers:
+	terraform providers lock -platform=linux_amd64 -platform=linux_arm64 -platform=darwin_amd64 -platform=darwin_arm64 -platform=windows_amd64

--- a/main.tf
+++ b/main.tf
@@ -1,27 +1,28 @@
 data "google_dns_managed_zone" "domains" {
-  for_each = var.subdomains
+  for_each = local.subdomains
 
   name = each.value
 }
 
 locals {
-  domain_names = {for key, _ in var.subdomains : key => trimsuffix(data.google_dns_managed_zone.domains[key].dns_name, ".")}
+  domain_names = { for key, _ in local.subdomains : key => trimsuffix(data.google_dns_managed_zone.domains[key].dns_name, ".") }
 }
 
 resource "google_certificate_manager_dns_authorization" "this" {
-  for_each = var.subdomains
+  for_each = local.subdomains
 
   name        = replace(each.key, ".", "-")
-  description = "Managed by Nullstone"
+  labels      = var.labels
+  description = "${each.key}: Created by Nullstone"
   domain      = local.domain_names[each.key]
 }
 
 locals {
-  auth_records = { for key, _ in var.subdomains : key => google_certificate_manager_dns_authorization.this[key].dns_resource_record.0 }
+  auth_records = { for key, _ in local.subdomains : key => google_certificate_manager_dns_authorization.this[key].dns_resource_record.0 }
 }
 
 resource "google_dns_record_set" "authorization_records" {
-  for_each = var.subdomains
+  for_each = local.subdomains
 
   managed_zone = each.value
   name         = local.auth_records[each.key].name
@@ -33,12 +34,28 @@ resource "google_dns_record_set" "authorization_records" {
 resource "google_certificate_manager_certificate" "this" {
   depends_on = [google_dns_record_set.authorization_records]
 
-  name        = var.cert_name
-  description = "Managed by Nullstone"
-  scope       = "EDGE_CACHE"
+  name        = var.name
+  labels      = var.labels
+  description = "Created by Nullstone"
+  scope       = var.scope
 
   managed {
-    domains            = [ for da in google_certificate_manager_dns_authorization.this : da.domain ]
-    dns_authorizations = [ for da in google_certificate_manager_dns_authorization.this : da.id ]
+    domains            = [for da in google_certificate_manager_dns_authorization.this : da.domain]
+    dns_authorizations = [for da in google_certificate_manager_dns_authorization.this : da.id]
   }
+}
+
+resource "google_certificate_manager_certificate_map" "this" {
+  name        = var.name
+  labels      = var.labels
+  description = "${var.name}: Created by Nullstone"
+}
+
+resource "google_certificate_manager_certificate_map_entry" "this" {
+  name         = var.name
+  labels       = var.labels
+  description  = "${var.name}: Created by Nullstone"
+  map          = google_certificate_manager_certificate_map.this.name
+  certificates = [google_certificate_manager_certificate.this.id]
+  matcher      = "PRIMARY"
 }

--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,7 @@ resource "google_dns_record_set" "authorization_records" {
 
 resource "google_certificate_manager_certificate" "this" {
   depends_on = [google_dns_record_set.authorization_records]
+  count      = var.enabled ? 1 : 0
 
   name        = var.name
   labels      = var.labels
@@ -50,16 +51,20 @@ resource "google_certificate_manager_certificate" "this" {
 }
 
 resource "google_certificate_manager_certificate_map" "this" {
+  count = var.enabled ? 1 : 0
+
   name        = var.name
   labels      = var.labels
   description = "${var.name}: Created by Nullstone"
 }
 
 resource "google_certificate_manager_certificate_map_entry" "this" {
+  count = var.enabled ? 1 : 0
+
   name         = var.name
   labels       = var.labels
   description  = "${var.name}: Created by Nullstone"
-  map          = google_certificate_manager_certificate_map.this.name
-  certificates = [google_certificate_manager_certificate.this.id]
+  map          = google_certificate_manager_certificate_map.this[count.index].name
+  certificates = [google_certificate_manager_certificate.this[count.index].id]
   matcher      = "PRIMARY"
 }

--- a/main.tf
+++ b/main.tf
@@ -7,8 +7,7 @@ data "google_dns_managed_zone" "domains" {
 data "google_client_config" "this" {}
 
 locals {
-  domain_names      = { for key, _ in local.subdomains : key => trimsuffix(data.google_dns_managed_zone.domains[key].dns_name, ".") }
-  dns_auth_location = var.scope == "EDGE_CACHE" ? null : data.google_client_config.this.region
+  domain_names = { for key, _ in local.subdomains : key => trimsuffix(data.google_dns_managed_zone.domains[key].dns_name, ".") }
 }
 
 resource "google_certificate_manager_dns_authorization" "this" {
@@ -18,7 +17,6 @@ resource "google_certificate_manager_dns_authorization" "this" {
   labels      = var.labels
   description = "${each.key}: Created by Nullstone"
   domain      = local.domain_names[each.key]
-  location    = local.dns_auth_location
 }
 
 locals {
@@ -42,7 +40,7 @@ resource "google_certificate_manager_certificate" "this" {
   name        = var.name
   labels      = var.labels
   description = "Created by Nullstone"
-  scope       = coalesce(var.scope, "DEFAULT")
+  scope       = var.scope == "" ? "DEFAULT" : var.scope
 
   managed {
     domains            = [for da in google_certificate_manager_dns_authorization.this : da.domain]

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,8 @@ output "certificate_id" {
   value       = google_certificate_manager_certificate.this.id
   description = "The ID of the certificate in GCP. (Format: projects/{{project}}/locations/global/certificates/{{name}})"
 }
+
+output "certificate_map_id" {
+  value       = google_certificate_manager_certificate_map.this.id
+  description = "The ID of the certificate map in GCP Certificate Manager. (Format: projects/{{project}}/locations/global/certificateMaps/{{name}})"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,14 +1,14 @@
 output "certificate_name" {
-  value       = google_certificate_manager_certificate.this.name
+  value       = try(google_certificate_manager_certificate.this[0].name, "")
   description = "The name of the certificate in GCP."
 }
 
 output "certificate_id" {
-  value       = google_certificate_manager_certificate.this.id
+  value       = try(google_certificate_manager_certificate.this[0].id, "")
   description = "The ID of the certificate in GCP. (Format: projects/{{project}}/locations/global/certificates/{{name}})"
 }
 
 output "certificate_map_id" {
-  value       = google_certificate_manager_certificate_map.this.id
+  value       = try(google_certificate_manager_certificate_map.this[0].id, "")
   description = "The ID of the certificate map in GCP Certificate Manager. (Format: projects/{{project}}/locations/global/certificateMaps/{{name}})"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,11 +35,18 @@ variable "labels" {
 
 variable "scope" {
   type        = string
-  default     = "DEFAULT"
+  default     = ""
   description = <<EOF
 The scope of the certificate relies on how the certificate will be used.
-- "EDGE_CACHE": For use with Cloud CDN
-- "ALL_REGIONS": For use with internet-facing load balancers
-- "DEFAULT": For use with backend services or private use
+- "": (default) For use with Load Balancing and Cloud CDN
+- "ALL_REGIONS": For use with cross-region internal application load balancing
+- "EDGE_CACHE": For use with media edge services
 EOF
+
+  validation {
+    condition     = contains(["EDGE_CACHE", "ALL_REGIONS", ""], var.scope)
+    error_message = <<EOF
+scope must be one of "EDGE_CACHE", "ALL_REGIONS", or ""
+EOF
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "enabled" {
   description = "This enables/disables creating the SSL certificate. We cannot use module count because we have aliased providers."
 }
 
-variable "cert_name" {
+variable "name" {
   type        = string
   description = <<EOF
 A user-defined name of the certificate.
@@ -20,5 +20,26 @@ variable "subdomains" {
 A list of subdomains represented as a map to register on the SSL certificate.
 In each key/value pair, the key refers to the DNS name of the subdomain and the value refers to the GCP unique zone name of the domain.
 If you want to use the dns_name from the domain zone, use `.` for the map key.
+EOF
+}
+
+locals {
+  subdomains = var.enabled ? var.subdomains : tomap({})
+}
+
+variable "labels" {
+  type        = map(string)
+  default     = {}
+  description = "A map of labels to apply to certificate resources"
+}
+
+variable "scope" {
+  type        = string
+  default     = "DEFAULT"
+  description = <<EOF
+The scope of the certificate relies on how the certificate will be used.
+- "EDGE_CACHE": For use with Cloud CDN
+- "ALL_REGIONS": For use with internet-facing load balancers
+- "DEFAULT": For use with backend services or private use
 EOF
 }


### PR DESCRIPTION
This generalizes the subdomain module for broad usage:
- Configured usage of var.enabled to disable/enable creation of certificate resources
- Added a Certificate Manager certificate map
- Added lockfile